### PR TITLE
fix: resolve blank notification items due to event payload schema mis…

### DIFF
--- a/frontend/src/NotificationContext.jsx
+++ b/frontend/src/NotificationContext.jsx
@@ -16,17 +16,50 @@ function stageLabel(stage) {
 }
 
 /**
- * Derives the emoji icon for a given event type.
+ * Resolves the canonical event kind from a raw WebSocket event object.
+ * Backend emits payloads with an "event" key (and an "event_type" from the
+ * Pydantic model); legacy / test payloads may use "type" instead.
  */
-function eventIcon(type) {
-  switch (type) {
-    case "stage_complete": return "✅";
-    case "stage_start":   return "▶️";
-    case "stage_error":   return "❌";
-    case "pipeline_complete": return "🎉";
-    case "clarification_needed": return "❓";
-    case "content_approval_needed": return "👀";
-    default: return "🔔";
+function resolveEventKind(event) {
+  return event.event ?? event.type ?? event.event_type ?? "";
+}
+
+/**
+ * Derives the emoji icon for a given (normalised) event kind.
+ */
+function eventIcon(kind) {
+  switch (kind) {
+    case "stage_completed":            return "✅";
+    case "stage_started":              return "▶️";
+    case "stage_error":                return "❌";
+    case "pipeline_completed":         return "🎉";
+    case "pipeline_started":           return "🚀";
+    case "clarification_requested":    return "❓";
+    case "content_approval_requested": return "👀";
+    default:                           return "🔔";
+  }
+}
+
+/**
+ * Builds a human-readable fallback message for events that carry no explicit
+ * "message" or "detail" field.
+ */
+function buildFallbackMessage(kind, stageText) {
+  switch (kind) {
+    case "pipeline_started":           return "Pipeline started";
+    case "pipeline_completed":         return "Pipeline completed";
+    case "stage_started":              return stageText ? `Started ${stageText}` : "Stage started";
+    case "stage_completed":            return stageText ? `Completed ${stageText}` : "Stage completed";
+    case "stage_error":                return stageText ? `Error in ${stageText}` : "Stage error";
+    case "clarification_requested":    return "Clarification requested";
+    case "clarification_completed":    return "Clarification completed";
+    case "content_approval_requested": return "Content approval requested";
+    case "content_approval_completed": return "Content approval completed";
+    case "wait_timeout":               return "Pipeline timed out waiting for input";
+    default:
+      return kind
+        ? kind.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+        : "Notification";
   }
 }
 
@@ -46,16 +79,20 @@ export function NotificationProvider({ children }) {
   const seenRef = useRef(new Set());
 
   const addEvent = useCallback((event) => {
-    const key = event.id ?? `${event.type}-${event.stage}-${event.timestamp}`;
+    const kind = resolveEventKind(event);
+    const key = event.id ?? `${kind}-${event.stage ?? ""}-${event.timestamp ?? ""}`;
     if (seenRef.current.has(key)) return;
     seenRef.current.add(key);
 
+    const stageText = stageLabel(event.stage || event.status);
+    const explicitMessage = event.message || event.detail || event.error || "";
+
     const item = {
       id: Math.random().toString(36).slice(2),
-      icon: eventIcon(event.type),
-      type: event.type,
-      stage: stageLabel(event.stage || event.status),
-      message: event.message || event.detail || "",
+      icon: eventIcon(kind),
+      type: kind,
+      stage: stageText,
+      message: explicitMessage || buildFallbackMessage(kind, stageText),
       timestamp: event.timestamp || new Date().toISOString(),
       read: false,
     };

--- a/frontend/src/test/NotificationCenter.test.jsx
+++ b/frontend/src/test/NotificationCenter.test.jsx
@@ -70,8 +70,8 @@ describe("NotificationCenter", () => {
 
   it("shows unread badge after events are pushed", () => {
     const events = [
-      { type: "stage_start", stage: "strategy", message: "Starting strategy", timestamp: new Date().toISOString() },
-      { type: "stage_complete", stage: "strategy", message: "Strategy done", timestamp: new Date().toISOString() },
+      { event: "stage_started", stage: "strategy", message: "Starting strategy", timestamp: new Date().toISOString() },
+      { event: "stage_completed", stage: "strategy", message: "Strategy done", timestamp: new Date().toISOString() },
     ];
     renderWithEvents(events);
 
@@ -87,7 +87,7 @@ describe("NotificationCenter", () => {
 
   it("shows events in the dropdown with stage, message, and timestamp", () => {
     const events = [
-      { type: "stage_start", stage: "content_generation", message: "Generating content", timestamp: new Date().toISOString() },
+      { event: "stage_started", stage: "content_generation", message: "Generating content", timestamp: new Date().toISOString() },
     ];
     renderWithEvents(events);
 
@@ -105,7 +105,7 @@ describe("NotificationCenter", () => {
 
   it("shows correct event icons", () => {
     const events = [
-      { type: "stage_error", stage: "review", message: "Failed", timestamp: new Date().toISOString() },
+      { event: "stage_error", stage: "review", message: "Failed", timestamp: new Date().toISOString() },
     ];
     renderWithEvents(events);
 
@@ -120,7 +120,7 @@ describe("NotificationCenter", () => {
 
   it("marks all notifications as read when dropdown is opened", () => {
     const events = [
-      { type: "stage_start", stage: "strategy", message: "Starting", timestamp: new Date().toISOString() },
+      { event: "stage_started", stage: "strategy", message: "Starting", timestamp: new Date().toISOString() },
     ];
     renderWithEvents(events);
 
@@ -165,8 +165,8 @@ describe("NotificationCenter", () => {
 
   it("deduplicates events by key", () => {
     const events = [
-      { type: "stage_start", stage: "strategy", message: "Starting", timestamp: "2026-03-20T10:00:00Z" },
-      { type: "stage_start", stage: "strategy", message: "Starting", timestamp: "2026-03-20T10:00:00Z" },
+      { event: "stage_started", stage: "strategy", message: "Starting", timestamp: "2026-03-20T10:00:00Z" },
+      { event: "stage_started", stage: "strategy", message: "Starting", timestamp: "2026-03-20T10:00:00Z" },
     ];
     renderWithEvents(events);
 
@@ -181,7 +181,7 @@ describe("NotificationCenter", () => {
 
   it("limits stored notifications to 20", () => {
     const events = Array.from({ length: 25 }, (_, i) => ({
-      type: "stage_start",
+      event: "stage_started",
       stage: `stage_${i}`,
       message: `Message ${i}`,
       timestamp: new Date(Date.now() + i * 1000).toISOString(),
@@ -200,7 +200,7 @@ describe("NotificationCenter", () => {
 
   it("marks individual notification as read on click", () => {
     const events = [
-      { type: "stage_start", stage: "strategy", message: "Starting", timestamp: new Date().toISOString() },
+      { event: "stage_started", stage: "strategy", message: "Starting", timestamp: new Date().toISOString() },
     ];
     renderWithEvents(events);
 
@@ -213,4 +213,94 @@ describe("NotificationCenter", () => {
     const item = screen.getByRole("listitem");
     expect(item.classList.contains("notification-item--unread")).toBe(false); // already marked read by opening panel
   });
-});
+  // -----------------------------------------------------------------------
+  // Backend event shape coverage (event field, not type)
+  // -----------------------------------------------------------------------
+
+  it("shows fallback message for pipeline_started event with no explicit message", () => {
+    const events = [
+      { event: "pipeline_started", campaign_id: "abc123", timestamp: new Date().toISOString() },
+    ];
+    renderWithEvents(events);
+
+    act(() => { fireEvent.click(screen.getByTestId("push-events")); });
+    fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+    expect(screen.getByText("Pipeline started")).toBeInTheDocument();
+  });
+
+  it("shows fallback message for pipeline_completed event with no explicit message", () => {
+    const events = [
+      { event: "pipeline_completed", campaign_id: "abc123", timestamp: new Date().toISOString() },
+    ];
+    renderWithEvents(events);
+
+    act(() => { fireEvent.click(screen.getByTestId("push-events")); });
+    fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+    expect(screen.getByText("Pipeline completed")).toBeInTheDocument();
+  });
+
+  it("derives 'Started {Stage}' fallback for stage_started with no message", () => {
+    const events = [
+      { event: "stage_started", event_type: "stage_started", campaign_id: "abc", stage: "strategy", timestamp: new Date().toISOString() },
+    ];
+    renderWithEvents(events);
+
+    act(() => { fireEvent.click(screen.getByTestId("push-events")); });
+    fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+    expect(screen.getByText("Started Strategy")).toBeInTheDocument();
+  });
+
+  it("resolves event kind from event field and shows correct icon", () => {
+    const events = [
+      { event: "stage_completed", stage: "strategy", timestamp: new Date().toISOString() },
+    ];
+    renderWithEvents(events);
+
+    act(() => { fireEvent.click(screen.getByTestId("push-events")); });
+    fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+    expect(screen.getByText("✅")).toBeInTheDocument();
+  });
+
+  it("shows 🚀 icon for pipeline_started event", () => {
+    const events = [
+      { event: "pipeline_started", campaign_id: "abc", timestamp: new Date().toISOString() },
+    ];
+    renderWithEvents(events);
+
+    act(() => { fireEvent.click(screen.getByTestId("push-events")); });
+    fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+    expect(screen.getByText("🚀")).toBeInTheDocument();
+  });
+
+  it("shows clarification_requested notification with correct text and icon", () => {
+    const events = [
+      { event: "clarification_requested", campaign_id: "abc", timestamp: new Date().toISOString() },
+    ];
+    renderWithEvents(events);
+
+    act(() => { fireEvent.click(screen.getByTestId("push-events")); });
+    fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+    expect(screen.getByText("❓")).toBeInTheDocument();
+    expect(screen.getByText("Clarification requested")).toBeInTheDocument();
+  });
+
+  it("never renders a blank notification item (no empty body)", () => {
+    // Minimal backend-shape event with no stage, no message, no detail
+    const events = [
+      { event: "pipeline_started", campaign_id: "abc", timestamp: new Date().toISOString() },
+    ];
+    renderWithEvents(events);
+
+    act(() => { fireEvent.click(screen.getByTestId("push-events")); });
+    fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+    const body = document.querySelector(".notification-item-body");
+    expect(body).not.toBeNull();
+    expect(body.textContent.trim()).not.toBe("");
+  });});


### PR DESCRIPTION
…match

- Add resolveEventKind() to normalize event kind from event/type/event_type
- Update eventIcon() to match backend event names (stage_started, stage_completed, clarification_requested, content_approval_requested, pipeline_started/completed)
- Add buildFallbackMessage() so items with no explicit message/detail always render meaningful text (e.g. 'Started Strategy', 'Pipeline started')
- Use event.error as an additional fallback for stage_error payloads
- Update deduplication key to use normalized kind instead of raw type field
- Update all test fixtures to backend-realistic event shape (event field)
- Add 7 new tests covering: pipeline_started/completed fallbacks, stage fallback text, icon resolution from event field, clarification icon/text, no-blank-body

Closes #425