### PR TITLE
fix: replace native sort select with custom themed dropdown (#462)

### DIFF
--- a/frontend/src/components/SortDropdown.jsx
+++ b/frontend/src/components/SortDropdown.jsx
@@ -1,0 +1,113 @@
+import { useState, useRef, useEffect } from "react";
+
+/**
+ * SortDropdown — custom themed dropdown that replaces the native <select>
+ * for campaign sorting. Fully respects dark/light theme via CSS variables.
+ *
+ * Props:
+ *   options   — array of { id, label }
+ *   value     — currently selected option id
+ *   onChange  — fn(value) called when an option is selected
+ *   ariaLabel — accessible label for the control
+ */
+export default function SortDropdown({ options, value, onChange, ariaLabel = "Sort" }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const listRef = useRef(null);
+  const selectedOption = options.find((o) => o.id === value) ?? options[0];
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        return;
+      }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const idx = options.findIndex((o) => o.id === value);
+        const next =
+          e.key === "ArrowDown"
+            ? Math.min(idx + 1, options.length - 1)
+            : Math.max(idx - 1, 0);
+        onChange(options[next].id);
+      }
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, value, options, onChange]);
+
+  const handleSelect = (id) => {
+    onChange(id);
+    setOpen(false);
+  };
+
+  return (
+    <div className="sort-dropdown" ref={containerRef}>
+      <button
+        type="button"
+        className="sort-dropdown__trigger"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+      >
+        <span className="sort-dropdown__label">{selectedOption.label}</span>
+        <svg
+          className={`sort-dropdown__chevron${open ? " sort-dropdown__chevron--open" : ""}`}
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <polyline
+            points="6 9 12 15 18 9"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <ul
+          ref={listRef}
+          className="sort-dropdown__menu"
+          role="listbox"
+          aria-label={ariaLabel}
+        >
+          {options.map((opt) => (
+            <li
+              key={opt.id}
+              role="option"
+              aria-selected={opt.id === value}
+              className={`sort-dropdown__item${opt.id === value ? " sort-dropdown__item--active" : ""}`}
+              onClick={() => handleSelect(opt.id)}
+            >
+              {opt.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -995,16 +995,80 @@ a:hover { color: var(--color-primary-hover); }
 .section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
 .section-header h2 { font-size: var(--text-2xl); }
 .section-header__controls { display: flex; align-items: center; gap: 0.75rem; }
-.sort-select {
+/* Sort Dropdown — custom themed dropdown */
+.sort-dropdown {
+  position: relative;
+  display: inline-block;
+}
+.sort-dropdown__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   font-size: var(--text-sm);
-  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  padding: 0.35rem 0.6rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   background: var(--color-surface);
   color: var(--color-text);
   cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  white-space: nowrap;
 }
-.sort-select:focus { border-color: var(--color-primary); outline: none; }
+.sort-dropdown__trigger:hover {
+  border-color: var(--color-primary);
+}
+.sort-dropdown__trigger:focus-visible {
+  border-color: var(--color-primary);
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+.sort-dropdown__label {
+  pointer-events: none;
+}
+.sort-dropdown__chevron {
+  transition: transform 0.2s ease;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+.sort-dropdown__chevron--open {
+  transform: rotate(180deg);
+}
+.sort-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 100%;
+  list-style: none;
+  margin: 0;
+  padding: 0.3rem 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  z-index: 50;
+  animation: sort-dropdown-enter 0.12s ease-out;
+}
+@keyframes sort-dropdown-enter {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.sort-dropdown__item {
+  padding: 0.4rem 0.75rem;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+.sort-dropdown__item:hover {
+  background: var(--color-surface-2);
+}
+.sort-dropdown__item--active {
+  color: var(--color-primary);
+  font-weight: 600;
+  background: var(--color-surface-2);
+}
 .page-title { font-size: var(--text-2xl); margin-bottom: 1rem; }
 .loading { display: flex; align-items: center; justify-content: center; padding: 2rem; color: var(--color-text-dim); }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ import WorkspaceSection from "../components/WorkspaceSection";
 import FilterTabs from "../components/FilterTabs";
 import SearchBar from "../components/SearchBar";
 import SavedViews from "../components/SavedViews";
+import SortDropdown from "../components/SortDropdown";
 import Toast from "../components/Toast";
 import useSavedViews from "../hooks/useSavedViews";
 import { applyFilter, matchesSearch, sortCampaigns } from "../lib/campaignFilters";
@@ -103,8 +104,7 @@ export default function Dashboard({ events }) {
     updateSearchParams(filter, search);
   };
 
-  const handleSortChange = (e) => {
-    const value = e.target.value;
+  const handleSortChange = (value) => {
     setSortBy(value);
     localStorage.setItem(SORT_STORAGE_KEY, value);
   };
@@ -421,18 +421,12 @@ export default function Dashboard({ events }) {
         <div className="section-header">
           <h2>Campaigns</h2>
           <div className="section-header__controls">
-            <select
-              className="sort-select"
+            <SortDropdown
+              options={SORT_OPTIONS}
               value={sortBy}
               onChange={handleSortChange}
-              aria-label="Sort campaigns"
-            >
-              {SORT_OPTIONS.map((opt) => (
-                <option key={opt.id} value={opt.id}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+              ariaLabel="Sort campaigns"
+            />
             {loading && campaigns.length > 0 && (
               <span className="campaign-list-loading" aria-live="polite">
                 <span className="spinner" />


### PR DESCRIPTION
Native <select>/<option> elements cannot be reliably styled across browsers — option backgrounds ignore CSS in most browsers, causing a white dropdown in dark mode.

Replace with a custom SortDropdown component that:
- Uses divs/buttons rendered via CSS variables (--color-surface, --color-text, etc.) for full dark/light theme support
- Supports keyboard navigation (arrows, Escape, Enter)
- Closes on outside click
- Animates open with a subtle fade+slide
- Shows active selection with primary color accent

Closes #462