### PR TITLE
fix: theme-aware custom dropdowns for Preferences and Notifications (…

### DIFF
--- a/frontend/src/components/FormSelect.jsx
+++ b/frontend/src/components/FormSelect.jsx
@@ -1,0 +1,130 @@
+import { useState, useRef, useEffect } from "react";
+
+/**
+ * FormSelect — custom themed dropdown for form fields.
+ * Full-width, inherits form-group sizing, fully themed via CSS variables.
+ *
+ * Props:
+ *   options   — array of { value, label }
+ *   value     — currently selected value
+ *   onChange  — fn(value) called when selection changes
+ *   id        — id for accessibility (label htmlFor)
+ *   ariaLabel — fallback accessible label
+ *   placeholder — text when no value selected
+ */
+export default function FormSelect({
+  options,
+  value,
+  onChange,
+  id,
+  ariaLabel,
+  placeholder = "Select…",
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const listRef = useRef(null);
+  const triggerRef = useRef(null);
+
+  const selectedOption = options.find((o) => o.value === value);
+  const displayLabel = selectedOption?.label ?? placeholder;
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const idx = options.findIndex((o) => o.value === value);
+        const next =
+          e.key === "ArrowDown"
+            ? Math.min(idx + 1, options.length - 1)
+            : Math.max(idx - 1, 0);
+        onChange(options[next].value);
+      }
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, value, options, onChange]);
+
+  const handleSelect = (val) => {
+    onChange(val);
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  return (
+    <div className="form-select-custom" ref={containerRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`form-select-custom__trigger${open ? " form-select-custom__trigger--open" : ""}`}
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        id={id}
+      >
+        <span className="form-select-custom__label">{displayLabel}</span>
+        <svg
+          className={`form-select-custom__chevron${open ? " form-select-custom__chevron--open" : ""}`}
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <polyline
+            points="6 9 12 15 18 9"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <ul
+          ref={listRef}
+          className="form-select-custom__menu"
+          role="listbox"
+          aria-label={ariaLabel || displayLabel}
+        >
+          {options.map((opt) => (
+            <li
+              key={opt.value}
+              role="option"
+              aria-selected={opt.value === value}
+              className={`form-select-custom__item${opt.value === value ? " form-select-custom__item--active" : ""}`}
+              onClick={() => handleSelect(opt.value)}
+            >
+              {opt.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -677,6 +677,94 @@ a:hover { color: var(--color-primary-hover); }
   margin-bottom: 0.75rem;
 }
 
+/* Custom form select — theme-aware dropdown replacing native <select> */
+.form-select-custom {
+  position: relative;
+  width: 100%;
+}
+.form-select-custom__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: border-color 0.15s;
+  text-align: left;
+}
+.form-select-custom__trigger:hover {
+  border-color: var(--color-primary);
+}
+.form-select-custom__trigger--open {
+  border-color: var(--color-primary);
+}
+.form-select-custom__trigger:focus-visible {
+  border-color: var(--color-primary);
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+.form-select-custom__label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  pointer-events: none;
+}
+.form-select-custom__chevron {
+  transition: transform 0.2s ease;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+.form-select-custom__chevron--open {
+  transform: rotate(180deg);
+}
+.form-select-custom__menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0.3rem 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  z-index: 50;
+  max-height: 240px;
+  overflow-y: auto;
+  animation: form-select-enter 0.12s ease-out;
+}
+@keyframes form-select-enter {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.form-select-custom__item {
+  padding: 0.45rem 0.75rem;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.1s;
+}
+.form-select-custom__item:hover {
+  background: var(--color-surface-2);
+}
+.form-select-custom__item--active {
+  color: var(--color-primary);
+  font-weight: 600;
+  background: var(--color-surface-2);
+}
+
 /* Form section grouping */
 .form-section {
   border: 1px solid var(--color-border);

--- a/frontend/src/pages/UserSettings.jsx
+++ b/frontend/src/pages/UserSettings.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { getMe, getMeSettings, patchMeSettings, listWorkspaces } from "../api";
 import { useToast } from "../ToastContext";
+import FormSelect from "../components/FormSelect";
 import { useThemeContext } from "../ThemeContext";
 
 const TABS = [
@@ -226,15 +227,13 @@ function PreferencesTab({ settings, onSettingsSaved }) {
       <form onSubmit={handleSave}>
         <div className="form-group">
           <label htmlFor="pref-theme">Theme</label>
-          <select
+          <FormSelect
             id="pref-theme"
+            options={THEME_OPTIONS}
             value={theme}
-            onChange={(e) => { setTheme(e.target.value); setValidationErrors((v) => ({ ...v, theme: undefined })); }}
-          >
-            {THEME_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
+            onChange={(val) => { setTheme(val); setValidationErrors((v) => ({ ...v, theme: undefined })); }}
+            ariaLabel="Theme"
+          />
           {validationErrors.theme && (
             <span data-testid="error-theme" style={{ color: "var(--color-danger)", fontSize: "0.75rem" }}>{validationErrors.theme}</span>
           )}
@@ -242,15 +241,13 @@ function PreferencesTab({ settings, onSettingsSaved }) {
 
         <div className="form-group">
           <label htmlFor="pref-locale">Locale</label>
-          <select
+          <FormSelect
             id="pref-locale"
+            options={LOCALE_OPTIONS}
             value={locale}
-            onChange={(e) => { setLocale(e.target.value); setValidationErrors((v) => ({ ...v, locale: undefined })); }}
-          >
-            {LOCALE_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
+            onChange={(val) => { setLocale(val); setValidationErrors((v) => ({ ...v, locale: undefined })); }}
+            ariaLabel="Locale"
+          />
           {validationErrors.locale && (
             <span data-testid="error-locale" style={{ color: "var(--color-danger)", fontSize: "0.75rem" }}>{validationErrors.locale}</span>
           )}
@@ -258,15 +255,13 @@ function PreferencesTab({ settings, onSettingsSaved }) {
 
         <div className="form-group">
           <label htmlFor="pref-timezone">Timezone</label>
-          <select
+          <FormSelect
             id="pref-timezone"
+            options={TIMEZONE_OPTIONS.map((tz) => ({ value: tz, label: tz }))}
             value={timezone}
-            onChange={(e) => { setTimezone(e.target.value); setValidationErrors((v) => ({ ...v, timezone: undefined })); }}
-          >
-            {TIMEZONE_OPTIONS.map((tz) => (
-              <option key={tz} value={tz}>{tz}</option>
-            ))}
-          </select>
+            onChange={(val) => { setTimezone(val); setValidationErrors((v) => ({ ...v, timezone: undefined })); }}
+            ariaLabel="Timezone"
+          />
           {validationErrors.timezone && (
             <span data-testid="error-timezone" style={{ color: "var(--color-danger)", fontSize: "0.75rem" }}>{validationErrors.timezone}</span>
           )}
@@ -274,16 +269,13 @@ function PreferencesTab({ settings, onSettingsSaved }) {
 
         <div className="form-group">
           <label htmlFor="pref-workspace">Default Workspace</label>
-          <select
+          <FormSelect
             id="pref-workspace"
+            options={[{ value: "", label: "None" }, ...workspaces.map((ws) => ({ value: ws.id, label: ws.name }))]}
             value={defaultWorkspaceId}
-            onChange={(e) => setDefaultWorkspaceId(e.target.value)}
-          >
-            <option value="">None</option>
-            {workspaces.map((ws) => (
-              <option key={ws.id} value={ws.id}>{ws.name}</option>
-            ))}
-          </select>
+            onChange={(val) => setDefaultWorkspaceId(val)}
+            ariaLabel="Default Workspace"
+          />
         </div>
 
         {saveError && (
@@ -437,15 +429,13 @@ function NotificationsTab({ settings, onSettingsSaved }) {
         {hasDigestFrequency && (
           <div className="form-group" style={{ marginTop: "0.25rem" }}>
             <label htmlFor="notif-digest-frequency">Digest frequency</label>
-            <select
+            <FormSelect
               id="notif-digest-frequency"
+              options={DIGEST_FREQUENCY_OPTIONS}
               value={digestFrequency}
-              onChange={(e) => setDigestFrequency(e.target.value)}
-            >
-              {DIGEST_FREQUENCY_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
-              ))}
-            </select>
+              onChange={(val) => setDigestFrequency(val)}
+              ariaLabel="Digest frequency"
+            />
           </div>
         )}
 

--- a/frontend/src/test/UserSettings.test.jsx
+++ b/frontend/src/test/UserSettings.test.jsx
@@ -2,7 +2,7 @@
  * Tests for UserSettings page — loading, error, success, and tab scaffold.
  */
 
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import UserSettings from '../pages/UserSettings';
@@ -60,7 +60,28 @@ function mockSuccessfulLoad(settingsOverrides = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Ensure localStorage is available for ThemeProvider in test env
+  if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.getItem !== 'function') {
+    const store = {};
+    globalThis.localStorage = {
+      getItem: (k) => store[k] ?? null,
+      setItem: (k, v) => { store[k] = String(v); },
+      removeItem: (k) => { delete store[k]; },
+      clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+    };
+  }
 });
+
+/**
+ * Helper: select a value from a FormSelect custom dropdown.
+ * Clicks the trigger button (found via label), then clicks the matching option.
+ */
+async function selectFormOption(labelRegex, optionText) {
+  const trigger = screen.getByLabelText(labelRegex);
+  fireEvent.click(trigger);
+  const listbox = await screen.findByRole('listbox', { name: labelRegex });
+  fireEvent.click(within(listbox).getByText(optionText));
+}
 
 describe('UserSettings – loading state', () => {
   it('shows loading indicator initially', () => {
@@ -233,9 +254,9 @@ describe('UserSettings – Preferences tab', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Preferences' }));
 
     await waitFor(() => expect(screen.getByTestId('tab-preferences')).toBeInTheDocument());
-    expect(screen.getByLabelText(/theme/i).value).toBe('dark');
-    expect(screen.getByLabelText(/locale/i).value).toBe('fr-FR');
-    expect(screen.getByLabelText(/timezone/i).value).toBe('Europe/Paris');
+    expect(screen.getByLabelText(/theme/i)).toHaveTextContent('Dark');
+    expect(screen.getByLabelText(/locale/i)).toHaveTextContent('French');
+    expect(screen.getByLabelText(/timezone/i)).toHaveTextContent('Europe/Paris');
   });
 
   it('saves preferences successfully', async () => {
@@ -248,7 +269,7 @@ describe('UserSettings – Preferences tab', () => {
 
     await waitFor(() => expect(screen.getByTestId('tab-preferences')).toBeInTheDocument());
 
-    fireEvent.change(screen.getByLabelText(/theme/i), { target: { value: 'dark' } });
+    await selectFormOption(/theme/i, 'Dark');
     fireEvent.click(screen.getByRole('button', { name: /save preferences/i }));
 
     await waitFor(() => expect(api.patchMeSettings).toHaveBeenCalledWith(
@@ -280,7 +301,7 @@ describe('UserSettings – Preferences tab', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Preferences' }));
 
     await waitFor(() => expect(screen.getByTestId('tab-preferences')).toBeInTheDocument());
-    fireEvent.change(screen.getByLabelText(/theme/i), { target: { value: 'dark' } });
+    await selectFormOption(/theme/i, 'Dark');
 
     expect(screen.getByTestId('unsaved-changes')).toBeInTheDocument();
     expect(screen.getByText(/unsaved changes/i)).toBeInTheDocument();
@@ -299,12 +320,11 @@ describe('UserSettings – Preferences tab', () => {
 
     await waitFor(() => expect(screen.getByTestId('tab-preferences')).toBeInTheDocument());
 
-    const wsSelect = screen.getByLabelText(/default workspace/i);
-    await waitFor(() => {
-      const options = Array.from(wsSelect.querySelectorAll('option'));
-      expect(options.map((o) => o.textContent)).toContain('Marketing');
-      expect(options.map((o) => o.textContent)).toContain('Engineering');
-    });
+    const wsTrigger = screen.getByLabelText(/default workspace/i);
+    fireEvent.click(wsTrigger);
+    const listbox = await screen.findByRole('listbox', { name: /default workspace/i });
+    expect(within(listbox).getByText('Marketing')).toBeInTheDocument();
+    expect(within(listbox).getByText('Engineering')).toBeInTheDocument();
   });
 
   it('sends correct patch payload with all preferences', async () => {
@@ -322,9 +342,9 @@ describe('UserSettings – Preferences tab', () => {
 
     await waitFor(() => expect(screen.getByTestId('tab-preferences')).toBeInTheDocument());
 
-    fireEvent.change(screen.getByLabelText(/theme/i), { target: { value: 'light' } });
-    fireEvent.change(screen.getByLabelText(/locale/i), { target: { value: 'de-DE' } });
-    fireEvent.change(screen.getByLabelText(/timezone/i), { target: { value: 'Europe/Berlin' } });
+    await selectFormOption(/theme/i, 'Light');
+    await selectFormOption(/locale/i, 'German');
+    await selectFormOption(/timezone/i, 'Europe/Berlin');
 
     fireEvent.click(screen.getByRole('button', { name: /save preferences/i }));
 
@@ -484,9 +504,9 @@ describe('UserSettings – Notifications tab', () => {
 
     await waitFor(() => expect(screen.getByTestId('tab-notifications')).toBeInTheDocument());
 
-    const select = screen.getByLabelText(/digest frequency/i);
-    expect(select).toBeInTheDocument();
-    expect(select.value).toBe('daily');
+    const trigger = screen.getByLabelText(/digest frequency/i);
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveTextContent('Daily digest');
   });
 
   it('does not show digest frequency when backend omits it', async () => {
@@ -554,7 +574,7 @@ describe('UserSettings – Notifications tab', () => {
 
     await waitFor(() => expect(screen.getByTestId('tab-notifications')).toBeInTheDocument());
 
-    fireEvent.change(screen.getByLabelText(/digest frequency/i), { target: { value: 'weekly' } });
+    await selectFormOption(/digest frequency/i, 'Weekly digest');
     fireEvent.click(screen.getByRole('button', { name: /save notifications/i }));
 
     await waitFor(() => expect(api.patchMeSettings).toHaveBeenCalledWith({


### PR DESCRIPTION
…#465)

Replace all native <select> elements in User Settings with a custom FormSelect component that respects dark/light theme via CSS variables.

- Add FormSelect.jsx — reusable custom dropdown (keyboard nav, ARIA listbox, outside-click close, animated open/close)
- Add .form-select-custom CSS styles to index.css (themed via --color-surface, --color-border, --color-text, --color-primary)
- Update UserSettings.jsx — replace 5 native selects (Theme, Locale, Timezone, Default Workspace, Digest Frequency) with FormSelect
- Update UserSettings.test.jsx — adapt tests for button-based dropdown interactions (click-to-open, option selection, text assertions)