### PR TITLE
fix: notification navigation & JIT user provisioning failures (#472)

### DIFF
--- a/backend/apps/worker/dependencies.py
+++ b/backend/apps/worker/dependencies.py
@@ -87,7 +87,7 @@ async def execute_job(job: WorkflowJob) -> None:
     workspace_id: str | None = getattr(campaign, "workspace_id", None)
 
     async def _on_event(event: str, data: dict) -> None:
-        enriched = data if "workspace_id" in data else {**data, "workspace_id": workspace_id}
+        enriched = data if data.get("workspace_id") else {**data, "workspace_id": workspace_id}
         await publisher.publish(event, enriched)
         campaign_id = enriched.get("campaign_id", job.campaign_id)
         stage = enriched.get("stage")

--- a/backend/infrastructure/auth.py
+++ b/backend/infrastructure/auth.py
@@ -183,6 +183,7 @@ async def _provision_user(
         updated_at=now,
     )
     db.add(workspace_row)
+    await db.flush()
 
     member_row = WorkspaceMemberRow(
         workspace_id=workspace_row.id,

--- a/backend/infrastructure/executors/in_process.py
+++ b/backend/infrastructure/executors/in_process.py
@@ -79,17 +79,23 @@ class InProcessExecutor:
         """
         publisher = InProcessEventPublisher(ws_manager)
         event_store = get_event_store()
+        store = get_campaign_store()
+
+        # Pre-fetch workspace_id so every event includes it (matches worker behaviour).
+        campaign_obj = await store.get(job.campaign_id)
+        workspace_id: str | None = getattr(campaign_obj, "workspace_id", None)
 
         async def _broadcast(event: str, data: dict[str, Any]) -> None:
-            await publisher.publish(event, data)
-            campaign_id = data.get("campaign_id") or job.campaign_id
-            stage = data.get("stage")
-            owner_id = data.get("owner_id")
+            enriched = data if data.get("workspace_id") else {**data, "workspace_id": workspace_id}
+            await publisher.publish(event, enriched)
+            campaign_id = enriched.get("campaign_id") or job.campaign_id
+            stage = enriched.get("stage")
+            owner_id = enriched.get("owner_id")
             try:
                 await event_store.save_event(
                     campaign_id=campaign_id,
                     event_type=event,
-                    payload=data,
+                    payload=enriched,
                     stage=stage,
                     owner_id=owner_id,
                 )
@@ -97,19 +103,17 @@ class InProcessExecutor:
                 logger.exception("EventStore.save_event failed for event %s", event)
 
         coordinator = CoordinatorAgent(on_event=_broadcast)
-        store = get_campaign_store()
 
         try:
             if job.action == "start_pipeline":
-                campaign = await store.get(job.campaign_id)
-                if campaign is None:
+                if campaign_obj is None:
                     logger.error(
                         "InProcessExecutor: campaign %s not found for start_pipeline",
                         job.campaign_id,
                     )
                     return
                 logger.info("InProcessExecutor: starting pipeline for campaign %s", job.campaign_id)
-                await coordinator.run_pipeline(campaign)
+                await coordinator.run_pipeline(campaign_obj)
                 logger.info("InProcessExecutor: pipeline completed for campaign %s", job.campaign_id)
 
             elif job.action == "resume_pipeline":

--- a/backend/tests/test_in_process_executor.py
+++ b/backend/tests/test_in_process_executor.py
@@ -106,6 +106,7 @@ class TestDispatch:
         executor = InProcessExecutor()
         mock_coord = _mock_coordinator()
         mock_store = MagicMock()
+        mock_store.get = AsyncMock(return_value=MagicMock())
 
         with (
             patch("backend.infrastructure.executors.in_process.CoordinatorAgent", return_value=mock_coord),
@@ -121,6 +122,7 @@ class TestDispatch:
         executor = InProcessExecutor()
         mock_coord = _mock_coordinator()
         mock_store = MagicMock()
+        mock_store.get = AsyncMock(return_value=MagicMock())
 
         with (
             patch("backend.infrastructure.executors.in_process.CoordinatorAgent", return_value=mock_coord),


### PR DESCRIPTION
- Enrich InProcessExecutor events with workspace_id (matches worker)
- Fix null-value enrichment bypass: use data.get() instead of 'in' check
- Add db.flush() after workspace insert to prevent FK violation
- Update tests for new campaign pre-fetch in executor