### PR TITLE
fix: resolve image generation end-to-end failures (#520)

### DIFF
--- a/backend/api/campaign_assets.py
+++ b/backend/api/campaign_assets.py
@@ -111,15 +111,29 @@ async def generate_asset(
     )
 
     gen_service = get_image_generation_service()
-    image_bytes = await gen_service.generate(prompt, dimensions)
+    try:
+        image_bytes = await gen_service.generate(prompt, dimensions)
+    except Exception:
+        logger.exception("Image generation failed for campaign %s, piece %d", campaign.id, idx)
+        raise HTTPException(
+            status_code=502,
+            detail="Image generation service returned an error. Check server logs for details.",
+        )
 
     storage_service = get_image_storage_service()
-    storage_path, image_url = await storage_service.upload(
-        campaign_id=campaign.id,
-        asset_id=asset.id,
-        image_bytes=image_bytes,
-        fmt=asset.format,
-    )
+    try:
+        storage_path, image_url = await storage_service.upload(
+            campaign_id=campaign.id,
+            asset_id=asset.id,
+            image_bytes=image_bytes,
+            fmt=asset.format,
+        )
+    except Exception:
+        logger.exception("Image storage upload failed for campaign %s, asset %s", campaign.id, asset.id)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to upload generated image to storage. Check server logs for details.",
+        )
 
     asset.storage_path = storage_path
     asset.image_url = image_url

--- a/backend/config.py
+++ b/backend/config.py
@@ -112,6 +112,8 @@ class ImageGenerationSettings(BaseSettings):
     """Image-generation feature settings."""
 
     enabled: bool = Field(default=False, alias="IMAGE_GENERATION_ENABLED")
+    model: str = Field(default="gpt-image-1.5", alias="IMAGE_GENERATION_MODEL")
+    endpoint: str = Field(default="", alias="IMAGE_GENERATION_ENDPOINT")
     azure_storage_account_url: str = Field(default="", alias="AZURE_STORAGE_ACCOUNT_URL")
     azure_storage_container: str = Field(default="campaign-images", alias="AZURE_STORAGE_CONTAINER")
 

--- a/backend/infrastructure/image_generation_service.py
+++ b/backend/infrastructure/image_generation_service.py
@@ -9,8 +9,8 @@ import logging
 import re
 
 import aiohttp
-from azure.ai.projects.aio import AIProjectClient
 from azure.identity.aio import DefaultAzureCredential
+from openai import AsyncOpenAI
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -24,24 +24,30 @@ logger = logging.getLogger(__name__)
 
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1F\x7F]")
 
+_AZURE_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default"
+
 
 class ImageGenerationService:
     """Generates image bytes from prompts using Azure AI image generation."""
 
     MAX_PROMPT_LENGTH = 4000
-    _DEFAULT_MODEL = "gpt-image-1"
 
     def __init__(self) -> None:
         settings = get_settings()
         cfg = settings.image_generation
 
         self._enabled = cfg.enabled
+        self._model = cfg.model
         self._credential = DefaultAzureCredential()
-        self._project_client = AIProjectClient(
-            endpoint=settings.azure_ai_project.endpoint,
-            credential=self._credential,
+        self._endpoint = cfg.endpoint
+
+    async def _get_client(self) -> AsyncOpenAI:
+        """Return an AsyncOpenAI client authenticated with a fresh Azure token."""
+        token = await self._credential.get_token(_AZURE_COGNITIVE_SCOPE)
+        return AsyncOpenAI(
+            base_url=self._endpoint,
+            api_key=token.token,
         )
-        self._client = self._project_client.get_openai_client()
 
     @staticmethod
     def _sanitize_prompt(prompt: str) -> str:
@@ -51,6 +57,24 @@ class ImageGenerationService:
         if len(cleaned) > ImageGenerationService.MAX_PROMPT_LENGTH:
             cleaned = cleaned[: ImageGenerationService.MAX_PROMPT_LENGTH]
         return cleaned
+
+    _SUPPORTED_SIZES = {"1024x1024", "1024x1536", "1536x1024", "auto"}
+
+    @staticmethod
+    def _normalize_dimensions(dimensions: str) -> str:
+        """Map arbitrary dimensions to the closest supported size."""
+        if dimensions in ImageGenerationService._SUPPORTED_SIZES:
+            return dimensions
+        try:
+            w, h = (int(x) for x in dimensions.split("x"))
+        except (ValueError, AttributeError):
+            return "auto"
+        ratio = w / h if h else 1.0
+        if ratio > 1.15:
+            return "1536x1024"  # landscape
+        elif ratio < 0.85:
+            return "1024x1536"  # portrait
+        return "1024x1024"  # square-ish
 
     @retry(
         retry=retry_if_exception_type(Exception),
@@ -66,13 +90,19 @@ class ImageGenerationService:
             )
 
         sanitized_prompt = self._sanitize_prompt(prompt)
+        normalized_dimensions = self._normalize_dimensions(dimensions)
 
-        logger.debug("Image generation request — dimensions=%s", dimensions)
-        response = await self._client.images.generate(
-            model=self._DEFAULT_MODEL,
-            prompt=sanitized_prompt,
-            size=dimensions,
-        )
+        client = await self._get_client()
+        try:
+            response = await client.images.generate(
+                model=self._model,
+                prompt=sanitized_prompt,
+                size=normalized_dimensions,
+            )
+        except Exception as exc:
+            raise
+        finally:
+            await client.close()
 
         image_data = response.data[0]
         b64_json = getattr(image_data, "b64_json", None)
@@ -89,9 +119,7 @@ class ImageGenerationService:
         raise RuntimeError("Image generation response did not contain image data.")
 
     async def close(self) -> None:
-        """Clean up underlying clients and credential."""
-        await self._client.close()
-        await self._project_client.close()
+        """Clean up underlying credential."""
         await self._credential.close()
 
 

--- a/backend/tests/test_image_generation_service.py
+++ b/backend/tests/test_image_generation_service.py
@@ -15,17 +15,34 @@ from backend.services.image_storage_service import ImageStorageService
 def image_generation_service():
     with (
         patch("backend.infrastructure.image_generation_service.get_settings") as mock_settings,
-        patch("backend.infrastructure.image_generation_service.DefaultAzureCredential"),
-        patch("backend.infrastructure.image_generation_service.AIProjectClient") as mock_project,
+        patch("backend.infrastructure.image_generation_service.DefaultAzureCredential") as mock_cred,
     ):
         mock_settings.return_value = MagicMock(
-            image_generation=MagicMock(enabled=True),
-            azure_ai_project=MagicMock(endpoint="https://project.example.com"),
+            image_generation=MagicMock(
+                enabled=True,
+                model="gpt-image-1.5",
+                endpoint="https://test.openai.azure.com/openai/v1/",
+            ),
         )
-        mock_openai_client = MagicMock()
-        mock_project.return_value.get_openai_client.return_value = mock_openai_client
+        mock_cred_instance = MagicMock()
+        mock_cred_instance.get_token = AsyncMock(return_value=MagicMock(token="fake-token"))
+        mock_cred.return_value = mock_cred_instance
         service = ImageGenerationService()
+        # Attach a mock client that tests can configure
+        service._mock_openai_client = MagicMock()
+        service._mock_openai_client.close = AsyncMock()
     return service
+
+
+def _patch_get_client(service, mock_response=None, side_effect=None):
+    """Helper to patch _get_client to return a mock OpenAI client."""
+    mock_client = service._mock_openai_client
+    if side_effect:
+        mock_client.images.generate = AsyncMock(side_effect=side_effect)
+    elif mock_response:
+        mock_client.images.generate = AsyncMock(return_value=mock_response)
+    service._get_client = AsyncMock(return_value=mock_client)
+    return mock_client
 
 
 class TestImageGenerationService:
@@ -35,13 +52,13 @@ class TestImageGenerationService:
         mock_image = MagicMock()
         mock_image.b64_json = base64.b64encode(expected).decode("ascii")
         mock_response = MagicMock(data=[mock_image])
-        image_generation_service._client.images.generate = AsyncMock(return_value=mock_response)
+        mock_client = _patch_get_client(image_generation_service, mock_response=mock_response)
 
         result = await image_generation_service.generate("A lighthouse at sunset")
 
         assert result == expected
-        kwargs = image_generation_service._client.images.generate.call_args[1]
-        assert kwargs["model"] == "gpt-image-1"
+        kwargs = mock_client.images.generate.call_args[1]
+        assert kwargs["model"] == "gpt-image-1.5"
         assert kwargs["size"] == "1024x1024"
 
     @pytest.mark.asyncio
@@ -49,29 +66,31 @@ class TestImageGenerationService:
         mock_image = MagicMock()
         mock_image.b64_json = base64.b64encode(b"x").decode("ascii")
         mock_response = MagicMock(data=[mock_image])
-        image_generation_service._client.images.generate = AsyncMock(return_value=mock_response)
+        mock_client = _patch_get_client(image_generation_service, mock_response=mock_response)
 
         prompt = "\x00Hello\x1f " + ("A" * (ImageGenerationService.MAX_PROMPT_LENGTH + 20))
-        await image_generation_service.generate(prompt, dimensions="512x512")
+        await image_generation_service.generate(prompt, dimensions="1536x1024")
 
-        kwargs = image_generation_service._client.images.generate.call_args[1]
+        kwargs = mock_client.images.generate.call_args[1]
         assert "\x00" not in kwargs["prompt"]
         assert "\x1f" not in kwargs["prompt"]
         assert len(kwargs["prompt"]) == ImageGenerationService.MAX_PROMPT_LENGTH
-        assert kwargs["size"] == "512x512"
+        assert kwargs["size"] == "1536x1024"
 
     @pytest.mark.asyncio
     async def test_generate_raises_when_disabled(self):
         with (
             patch("backend.infrastructure.image_generation_service.get_settings") as mock_settings,
-            patch("backend.infrastructure.image_generation_service.DefaultAzureCredential"),
-            patch("backend.infrastructure.image_generation_service.AIProjectClient") as mock_project,
+            patch("backend.infrastructure.image_generation_service.DefaultAzureCredential") as mock_cred,
         ):
             mock_settings.return_value = MagicMock(
-                image_generation=MagicMock(enabled=False),
-                azure_ai_project=MagicMock(endpoint="https://project.example.com"),
+                image_generation=MagicMock(
+                    enabled=False,
+                    model="gpt-image-1.5",
+                    endpoint="https://test.openai.azure.com/openai/v1/",
+                ),
             )
-            mock_project.return_value.get_openai_client.return_value = MagicMock()
+            mock_cred.return_value = MagicMock()
             service = ImageGenerationService()
 
         with pytest.raises(RuntimeError, match="Image generation is disabled"):
@@ -82,23 +101,25 @@ class TestImageGenerationService:
         mock_image = MagicMock()
         mock_image.b64_json = base64.b64encode(b"ok").decode("ascii")
         mock_response = MagicMock(data=[mock_image])
-        image_generation_service._client.images.generate = AsyncMock(
-            side_effect=[Exception("transient"), mock_response]
+        mock_client = _patch_get_client(
+            image_generation_service,
+            side_effect=[Exception("transient"), mock_response],
         )
 
         result = await image_generation_service.generate("test")
         assert result == b"ok"
-        assert image_generation_service._client.images.generate.call_count == 2
+        assert mock_client.images.generate.call_count == 2
 
     @pytest.mark.asyncio
     async def test_generate_raises_after_max_retries(self, image_generation_service):
-        image_generation_service._client.images.generate = AsyncMock(
-            side_effect=Exception("permanent")
+        mock_client = _patch_get_client(
+            image_generation_service,
+            side_effect=Exception("permanent"),
         )
 
         with pytest.raises(Exception, match="permanent"):
             await image_generation_service.generate("test")
-        assert image_generation_service._client.images.generate.call_count == 3
+        assert mock_client.images.generate.call_count == 3
 
     @pytest.mark.asyncio
     async def test_generate_rejects_empty_prompt_after_sanitization(self, image_generation_service):

--- a/frontend/src/NotificationContext.jsx
+++ b/frontend/src/NotificationContext.jsx
@@ -36,6 +36,7 @@ function eventIcon(kind) {
     case "pipeline_started":           return "🚀";
     case "clarification_requested":    return "❓";
     case "content_approval_requested": return "👀";
+    case "image_generated":             return "🖼️";
     default:                           return "🔔";
   }
 }
@@ -55,6 +56,7 @@ function buildFallbackMessage(kind, stageText) {
     case "clarification_completed":    return "Clarification completed";
     case "content_approval_requested": return "Content approval requested";
     case "content_approval_completed": return "Content approval completed";
+    case "image_generated":             return "Image generated";
     case "wait_timeout":               return "Pipeline timed out waiting for input";
     default:
       return kind

--- a/frontend/src/components/ContentSection.jsx
+++ b/frontend/src/components/ContentSection.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { submitContentApproval, updatePieceNotes, updatePieceDecision, generateImageAsset } from "../api";
 import { useConfirm } from "../ConfirmDialogContext";
 import { useToast } from "../ToastContext";
+import { useNotifications } from "../NotificationContext";
 import ImageAssetCard from "./ImageAssetCard";
 
 const PLATFORM_LABELS = {
@@ -61,6 +62,7 @@ export default function ContentSection({
 }) {
   const confirm = useConfirm();
   const { addToast } = useToast();
+  const { addEvent } = useNotifications();
   const [editing, setEditing] = useState({});      // { [index]: editedText }
   const [notes, setNotes] = useState({});           // { [index]: noteText }
   const [decisions, setDecisions] = useState({});   // { [index]: "approved" | "rejected" }
@@ -164,8 +166,20 @@ export default function ContentSection({
     try {
       await generateImageAsset(workspaceId, campaignId, pieceIndex);
       onImageGenerated?.();
+      addToast({ type: "success", stage: "Image Generated", message: `Image for content piece ${pieceIndex + 1} generated successfully.` });
+      addEvent({
+        type: "image_generated",
+        stage: "image_generation",
+        message: `Image for content piece ${pieceIndex + 1} generated successfully.`,
+        campaign_id: campaignId,
+        workspace_id: workspaceId,
+        timestamp: new Date().toISOString(),
+      });
     } catch (err) {
-      setImageErrors((prev) => ({ ...prev, [pieceIndex]: err.message }));
+      const detail = err.body?.detail ?? err.detail ?? err.message;
+      const status = err.status ?? "unknown";
+      console.error(`[ImageGeneration] Failed for piece ${pieceIndex}: HTTP ${status} — ${detail}`, err.body ?? err);
+      setImageErrors((prev) => ({ ...prev, [pieceIndex]: `HTTP ${status}: ${detail}` }));
     } finally {
       setGeneratingImages((prev) => ({ ...prev, [pieceIndex]: false }));
     }

--- a/frontend/src/components/ImageGallerySection.jsx
+++ b/frontend/src/components/ImageGallerySection.jsx
@@ -33,7 +33,7 @@ export default function ImageGallerySection({ workspaceId, campaignId, events, i
   const load = useCallback(async () => {
     try {
       const data = await listImageAssets(workspaceId, campaignId);
-      setAssets(data?.assets ?? []);
+      setAssets(data?.items ?? []);
     } catch (err) {
       setError(err.message);
     }
@@ -150,7 +150,7 @@ export default function ImageGallerySection({ workspaceId, campaignId, events, i
               ✕
             </button>
             <img
-              src={lightbox.url}
+              src={lightbox.image_url || lightbox.url}
               alt={lightbox.prompt ? truncatePrompt(lightbox.prompt, 80) : "Generated image"}
               className="image-gallery-lightbox-img"
             />

--- a/frontend/src/pages/CampaignDetail.jsx
+++ b/frontend/src/pages/CampaignDetail.jsx
@@ -184,7 +184,7 @@ export default function CampaignDetail() {
     if (!effectiveWorkspaceId || !campaign?.id || !imageGenerationEnabled) return;
     try {
       const data = await listImageAssets(effectiveWorkspaceId, campaign.id);
-      setImageAssets(data?.assets ?? []);
+      setImageAssets(data?.items ?? []);
     } catch {
       // silently ignore — gallery section handles errors independently
     }


### PR DESCRIPTION
- Rewrite ImageGenerationService to use direct Azure OpenAI endpoint instead of AI Foundry project endpoint (404 on images.generate)
- Add IMAGE_GENERATION_MODEL and IMAGE_GENERATION_ENDPOINT config fields
- Add dimension normalization for unsupported sizes (e.g. 1080x1350)
- Add try/except error handling in campaign_assets API (502 vs bare 500)
- Fix frontend response field mismatch (items vs assets)
- Fix lightbox broken image (image_url vs url)
- Add success toast and notification center entry on image generation

Closes #519
Closes #520